### PR TITLE
Add tellI

### DIFF
--- a/src/ReaderTaskWriterEither.ts
+++ b/src/ReaderTaskWriterEither.ts
@@ -20,6 +20,16 @@ export const chain: <R, E, A, B>(
   f: (a: A) => ReaderTaskWriterEither<R, E, B>,
 ) => (fa: ReaderTaskWriterEither<R, E, A>) => ReaderTaskWriterEither<R, E, B> = chainW
 
+export const map: <A, B>(
+  f: (a: A) => B,
+) => <R, E>(fa: ReaderTaskWriterEither<R, E, A>) => ReaderTaskWriterEither<R, E, B> = (
+  f,
+) => (fa) => (r) =>
+  pipe(
+    fa(r),
+    TWE.map((a) => f(a)),
+  )
+
 export const orElseW: <R, E1, E2, B>(
   onLeft: (e: E1) => ReaderTaskWriterEither<R, E2, B>,
 ) => <A>(

--- a/src/ReaderTaskWriterEither.ts
+++ b/src/ReaderTaskWriterEither.ts
@@ -69,3 +69,21 @@ export const traverseArray = <R, E, A, B>(
       return [log, either]
     })
 }
+
+export const tell: <R, E, A>(
+  m: string,
+) => (fa: ReaderTaskWriterEither<R, E, A>) => ReaderTaskWriterEither<R, E, A> = (m) => (
+  fa,
+) => (r) => async () =>
+  Promise.resolve()
+    .then(fa(r))
+    .then(([ma, a]) => (E.isRight(a) ? [[...ma, m], a] : [ma, a]))
+
+export const tellI: <R, E, A>(
+  fm: (a: A) => string,
+) => (fa: ReaderTaskWriterEither<R, E, A>) => ReaderTaskWriterEither<R, E, A> = (
+  fm,
+) => (fa) => (r) => async () =>
+  Promise.resolve()
+    .then(fa(r))
+    .then(([ma, a]) => (E.isRight(a) ? [[...ma, fm(a.right)], a] : [ma, a]))

--- a/src/TaskWriterEither.ts
+++ b/src/TaskWriterEither.ts
@@ -40,6 +40,14 @@ export const tell: <E, A>(
     .then(fa)
     .then(([ma, a]) => (E.isRight(a) ? [[...ma, m], a] : [ma, a]))
 
+export const tellI: <E, A>(
+  fm: (a: A) => string,
+) => (fa: TaskWriterEither<E, A>) => TaskWriterEither<E, A> = (fm) => (
+  fa,
+) => async () =>
+  Promise.resolve()
+    .then(fa)
+    .then(([ma, a]) => (E.isRight(a) ? [[...ma, fm(a.right)], a] : [ma, a]))
 
 export const chainW: <E1, A, E2, B>(
   f: (a: A) => TaskWriterEither<E2, B>,

--- a/src/TaskWriterEither.ts
+++ b/src/TaskWriterEither.ts
@@ -38,7 +38,8 @@ export const tell: <E, A>(
 ) => (fa: TaskWriterEither<E, A>) => TaskWriterEither<E, A> = (m) => (fa) => async () =>
   Promise.resolve()
     .then(fa)
-    .then(([ma, a]) => [[...ma, m], a])
+    .then(([ma, a]) => (E.isRight(a) ? [[...ma, m], a] : [ma, a]))
+
 
 export const chainW: <E1, A, E2, B>(
   f: (a: A) => TaskWriterEither<E2, B>,


### PR DESCRIPTION
feat: add tell/tellI

Add the following functions:

- TaskWriterEither
- tellI
- ReaderTaskWriterEither
- tell
- tellI

We take this opportunity to add a new suffix convention, like `W` for
`widen` or `K` for `kleisli`: `I`, for `identity`.

Instead of the following pattern:

```typescript
pipe(
  TWE.tryCatch('launching missiles')(launchMissiles, (error) => error),
  TWE.chain((result) => TWE.of(`result: ${result`)(result)),
)
```

(in other words, a `tell` where we want to use the value of `a` in the
log), we can indicate that `chain` returns the given value (aka the
`identity` function) with `tellI`:

```typescript
pipe(
  TWE.tryCatch('launching missiles')(launchMissiles, (error) => error),
  TWE.tellI((result) => `result: ${result`),
)
```

I'm not sure if there's a pattern for this in more functional languages,
or if I'm using `tell` incorrectly, but this pattern will be useful for
explicit logs so we will give it a shot. Please drop me a line if this
is an identifiable anti-pattern.
